### PR TITLE
Don't throw exception when character has no reputations.

### DIFF
--- a/src/app/popup/popup/popup.component.ts
+++ b/src/app/popup/popup/popup.component.ts
@@ -89,7 +89,7 @@ export class PopupComponent {
 
   public dominantReputationToText(character: IChatRoomCharacter) {
     let dominant = 0;
-    const rep = character.Reputation.find(r => r.Type === 'Dominant');
+    const rep = (character.Reputation || []).find(r => r.Type === 'Dominant');
     if (rep) {
       dominant = rep.Value;
     }


### PR DESCRIPTION
Characters with no reputation (such as new characters) seem to be synced to the popup with `character.Reputation` undefined causing them to break the online character list.

This PR guards against the error by defaulting to an empty reputation list when that happens.

[Example image to illustrate the problem/fix](https://mega.nz/file/sltxQJyC#jrpKmbn1dsfrkz8AtutRVo-pxTdz8GFHwwUNkzw_mas).
