### PR TITLE
Bugfix: Character list clearing when using some chat functions

### DIFF
--- a/models/IVariablesUpdate.ts
+++ b/models/IVariablesUpdate.ts
@@ -4,4 +4,5 @@ export interface IVariablesUpdate {
   ChatRoomSpace: ChatRoomSpace;
   CurrentScreen: CurrentScreen;
   Player: IPlayer;
+  InChat: boolean;
 }

--- a/models/game/CurrentScreen.ts
+++ b/models/game/CurrentScreen.ts
@@ -2,5 +2,8 @@
 export type CurrentScreen =
   'ChatRoom' |
   'ChatSearch' |
+  'ChatAdmin' |
   'Login' |
-  'MainHall';
+  'MainHall' |
+  'InformationSheet' | 'Preference' | 'FriendList' | 'Title' | 'OnlineProfile' |
+  'Appearance';

--- a/projects/background/src/main.ts
+++ b/projects/background/src/main.ts
@@ -180,7 +180,7 @@ function handleVariablesUpdate(tabId: number, message: IServerMessage<IVariables
   }
 
   store(tabId, 'player', message.data.Player);
-  if (message.data.CurrentScreen !== 'ChatRoom') {
+  if (!message.data.InChat) {
     store(tabId, 'chatRoomCharacter', []);
   }
 }

--- a/projects/content-script/src/server-event-listeners.ts
+++ b/projects/content-script/src/server-event-listeners.ts
@@ -65,6 +65,23 @@ export function pollVariables(handshake: string) {
     return JSON.parse(JSON.stringify(obj));
   }
 
+  function isInChat() {
+    switch(window.CurrentScreen) {
+      case 'ChatRoom':
+      case 'ChatAdmin':
+        return true;
+      case 'Appearance':
+        return window.CharacterAppearanceReturnRoom === 'ChatRoom';
+      case 'InformationSheet':
+      case 'Preference':
+      case 'FriendList':
+      case 'Title':
+      case 'OnlineProfile':
+        return window.InformationSheetPreviousScreen === 'ChatRoom';
+    }
+    return false;
+  }
+
   setInterval(() => {
     window.postMessage({
       handshake,
@@ -73,6 +90,7 @@ export function pollVariables(handshake: string) {
       data: {
         ChatRoomSpace: sanitizeObject(window.ChatRoomSpace),
         CurrentScreen: sanitizeObject(window.CurrentScreen),
+        InChat: isInChat(),
         Player: sanitizeObject(window.Player)
       }
     }, '*');

--- a/projects/content-script/src/window-extensions.d.ts
+++ b/projects/content-script/src/window-extensions.d.ts
@@ -9,6 +9,8 @@ declare global {
     ChatRoomData: IChatRoom;
     ChatRoomSpace: ChatRoomSpace;
     CurrentScreen: CurrentScreen;
+    CharacterAppearanceReturnRoom: CurrentScreen;
+    InformationSheetPreviousScreen: CurrentScreen;
     Player: IPlayer;
     ServerSocket: SocketIO.Server;
     TimerProcess: typeof TimerProcess;


### PR DESCRIPTION
Opening "Dress your character", "Your character profile" or "Room administration" clears the character list until the next sync event due to the game changing the CurrentScreen variable.

This PR adds a check for any of those screens when sending the variable update to the background script.

To avoid having to send additional data I added an InChatRoom boolean that is used for the character clear check instead of .CurrentScreen !== 'ChatRoom'.